### PR TITLE
[MOB-21285] Refactor Core for multiple Event Hubs

### DIFF
--- a/AEPCore.xcodeproj/project.pbxproj
+++ b/AEPCore.xcodeproj/project.pbxproj
@@ -416,6 +416,10 @@
 		92F06BFC25B8F1FE004C1700 /* MessageMonitoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F06BFB25B8F1FE004C1700 /* MessageMonitoring.swift */; };
 		92F06D0425BA33F4004C1700 /* Showable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F06D0325BA33F3004C1700 /* Showable.swift */; };
 		AC1089C926DD87C0004ABAC4 /* XDMLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1089C826DD87C0004ABAC4 /* XDMLanguage.swift */; };
+		AC6073022C4E420F00170028 /* Tenant.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC6073012C4E420F00170028 /* Tenant.swift */; };
+		AC6073042C4E432100170028 /* TenantAwareExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC6073032C4E432100170028 /* TenantAwareExtension.swift */; };
+		AC6073362C4E452C00170028 /* EventHub+Tenant.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC6073352C4E452C00170028 /* EventHub+Tenant.swift */; };
+		AC6073382C4EE21300170028 /* MobileCore+Tenant.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC6073372C4EE21300170028 /* MobileCore+Tenant.swift */; };
 		ACC7A9762A0EA51F001A04FB /* EventHistoryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC7A9752A0EA51F001A04FB /* EventHistoryIntegrationTests.swift */; };
 		ACC7A97B2A12AF9D001A04FB /* rules_attach.json in Resources */ = {isa = PBXBuildFile; fileRef = ACC7A9792A12AF9D001A04FB /* rules_attach.json */; };
 		ACC7A97C2A12AF9D001A04FB /* rules_attach.zip in Resources */ = {isa = PBXBuildFile; fileRef = ACC7A97A2A12AF9D001A04FB /* rules_attach.zip */; };
@@ -1136,6 +1140,10 @@
 		AA4461A0B65C5DFE219540A5 /* Pods-TestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestApp.release.xcconfig"; path = "Target Support Files/Pods-TestApp/Pods-TestApp.release.xcconfig"; sourceTree = "<group>"; };
 		AC1089C826DD87C0004ABAC4 /* XDMLanguage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XDMLanguage.swift; sourceTree = "<group>"; };
 		AC4D8D4526D9AC0200A86435 /* EventTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventTests.swift; sourceTree = "<group>"; };
+		AC6073012C4E420F00170028 /* Tenant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tenant.swift; sourceTree = "<group>"; };
+		AC6073032C4E432100170028 /* TenantAwareExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TenantAwareExtension.swift; sourceTree = "<group>"; };
+		AC6073352C4E452C00170028 /* EventHub+Tenant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EventHub+Tenant.swift"; sourceTree = "<group>"; };
+		AC6073372C4EE21300170028 /* MobileCore+Tenant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MobileCore+Tenant.swift"; sourceTree = "<group>"; };
 		AC838996795DECE800B0A11B /* Pods-AEPIdentityTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPIdentityTests.release.xcconfig"; path = "Target Support Files/Pods-AEPIdentityTests/Pods-AEPIdentityTests.release.xcconfig"; sourceTree = "<group>"; };
 		ACC7A9752A0EA51F001A04FB /* EventHistoryIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHistoryIntegrationTests.swift; sourceTree = "<group>"; };
 		ACC7A9792A12AF9D001A04FB /* rules_attach.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rules_attach.json; sourceTree = "<group>"; };
@@ -2001,6 +2009,7 @@
 				216A15C7257818B200D43848 /* Data+HexString.swift */,
 				BBA1E96725F0506B00999DD2 /* DataMarshaller.swift */,
 				7522C4832C233ACD004AF637 /* Event+Debug.swift */,
+				AC6073372C4EE21300170028 /* MobileCore+Tenant.swift */,
 			);
 			path = core;
 			sourceTree = "<group>";
@@ -2024,6 +2033,9 @@
 				3FB66AAB24CA004400502CAF /* SharedState.swift */,
 				217E220424D1FD7900B70B3E /* SharedStateResult.swift */,
 				21A6737225434AE600A7E906 /* SharedStateType.swift */,
+				AC6073012C4E420F00170028 /* Tenant.swift */,
+				AC6073032C4E432100170028 /* TenantAwareExtension.swift */,
+				AC6073352C4E452C00170028 /* EventHub+Tenant.swift */,
 			);
 			path = eventhub;
 			sourceTree = "<group>";
@@ -3235,6 +3247,7 @@
 				216A15C8257818B200D43848 /* Data+HexString.swift in Sources */,
 				3F2B1DC5263221580030F50B /* LaunchRulesEngine+Downloader.swift in Sources */,
 				3FB66AC524CA004400502CAF /* CoreConstants.swift in Sources */,
+				AC6073042C4E432100170028 /* TenantAwareExtension.swift in Sources */,
 				3FB66AE224CA004400502CAF /* Event+Configuration.swift in Sources */,
 				3FB66AD124CA004400502CAF /* SharedState.swift in Sources */,
 				215A6CE224ED92C500FE0657 /* V4MigrationConstants.swift in Sources */,
@@ -3247,6 +3260,7 @@
 				3F2B1DA62631E7FE0030F50B /* RuleConsequence.swift in Sources */,
 				24EDE33326EFB7470068A65F /* EventHistoryRequest.swift in Sources */,
 				3FB66AE324CA004400502CAF /* ConfigurationDownloadable.swift in Sources */,
+				AC6073362C4E452C00170028 /* EventHub+Tenant.swift in Sources */,
 				3FB66ADB24CA004400502CAF /* LaunchRulesEngine.swift in Sources */,
 				21377D4124E3383E004BAC01 /* V4Migrator.swift in Sources */,
 				3FB66ACA24CA004400502CAF /* MobileCore+Lifecycle.swift in Sources */,
@@ -3263,6 +3277,7 @@
 				3FB66AD824CA004400502CAF /* Extension.swift in Sources */,
 				BB00E26E24D9BFB700C578C1 /* URLUtility.swift in Sources */,
 				3FB66AD724CA004400502CAF /* EventListenerContainer.swift in Sources */,
+				AC6073382C4EE21300170028 /* MobileCore+Tenant.swift in Sources */,
 				3FB66AD224CA004400502CAF /* EventHub.swift in Sources */,
 				3FB66ADC24CA004400502CAF /* RulesLoader.swift in Sources */,
 				3FB66ACC24CA004400502CAF /* EventHubPlaceholderExtension.swift in Sources */,
@@ -3272,6 +3287,7 @@
 				3FB66AE124CA004400502CAF /* LaunchIDManager.swift in Sources */,
 				3F08FF9524D9F1D200D34DE3 /* EventDataMerger.swift in Sources */,
 				3FB66AD024CA004400502CAF /* AEPError.swift in Sources */,
+				AC6073022C4E420F00170028 /* Tenant.swift in Sources */,
 				3FB66AD424CA004400502CAF /* EventType.swift in Sources */,
 				3F5D45F8251903030040E298 /* LaunchRuleTransformer.swift in Sources */,
 				7522618D2AABBE9600D59847 /* UserDefaultMigrationConstants.swift in Sources */,

--- a/AEPCore/Sources/configuration/Configuration.swift
+++ b/AEPCore/Sources/configuration/Configuration.swift
@@ -14,35 +14,46 @@ import AEPServices
 import Foundation
 
 /// Responsible for retrieving the configuration of the SDK and updating the shared state and dispatching configuration updates through the `EventHub`
-class Configuration: NSObject, Extension {
+class Configuration: NSObject, TenantAwareExtension {
     let runtime: ExtensionRuntime
+    let tenant: Tenant
     let name = ConfigurationConstants.EXTENSION_NAME
     let friendlyName = ConfigurationConstants.FRIENDLY_NAME
     public static let extensionVersion = ConfigurationConstants.EXTENSION_VERSION
     let metadata: [String: String]? = nil
 
-    private let dataStore = NamedCollectionDataStore(name: ConfigurationConstants.DATA_STORE_NAME)
+    private let dataStore: NamedCollectionDataStore
     private var appIdManager: LaunchIDManager
     private var configState: ConfigurationState // should only be modified/used within the event queue
-    private let rulesEngine: LaunchRulesEngine
-    private let retryQueue = DispatchQueue(label: "com.adobe.configuration.retry")
     private let rulesEngineName = "\(ConfigurationConstants.EXTENSION_NAME).rulesengine"
+    private let rulesEngine: LaunchRulesEngine
+    private let retryQueue: DispatchQueue
     private var retryConfigurationCounter: Double = 1
 
     // MARK: - Extension
 
     /// Initializes the Configuration extension and it's dependencies
-    required init(runtime: ExtensionRuntime) {
+    required init(runtime: ExtensionRuntime, tenant: Tenant) {
         self.runtime = runtime
-        rulesEngine = LaunchRulesEngine(name: rulesEngineName, extensionRuntime: runtime)
+        self.tenant = tenant
 
+        rulesEngine = LaunchRulesEngine(name: rulesEngineName.tenantAwareName(for: tenant), extensionRuntime: runtime)
+
+        dataStore = NamedCollectionDataStore(name: ConfigurationConstants.DATA_STORE_NAME.tenantAwareName(for: tenant))
         appIdManager = LaunchIDManager(dataStore: dataStore)
         configState = ConfigurationState(dataStore: dataStore, configDownloader: ConfigurationDownloader())
+
+        retryQueue = DispatchQueue(label: "com.adobe.configuration.retry".tenantAwareName(for: tenant))
+    }
+
+    /// Initializes the Configuration extension and it's dependencies
+    required convenience init(runtime: ExtensionRuntime) {
+        self.init(runtime: runtime, tenant: .default)
     }
 
     /// Invoked when the Configuration extension has been registered by the `EventHub`, this results in the Configuration extension loading the first configuration for the SDK
     func onRegistered() {
-        registerPreprocessor(rulesEngine.process(event:))
+        registerPreprocessor(tenant, rulesEngine.process(event:))
 
         registerListener(type: EventType.configuration, source: EventSource.requestContent, listener: receiveConfigurationRequest(event:))
 

--- a/AEPCore/Sources/core/MobileCore+Tenant.swift
+++ b/AEPCore/Sources/core/MobileCore+Tenant.swift
@@ -1,0 +1,111 @@
+//
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+import AEPServices
+
+// Adding these convenience APIs for testing purposes. Further investigation is needed for public APIs.
+public extension MobileCore {
+    static func registerExtensions(tenantID: String, _ extensions: [NSObject.Type], _ completion: (() -> Void)? = nil) {
+        // Register native extensions
+        let registeredCounter = AtomicCounter()
+        let tenantAwareExtensions = extensions.filter {
+            let isSupported = ($0.self is TenantAwareExtension.Type)
+            if !isSupported {
+                Log.error(label: LOG_TAG, "\($0.self) extension will not be registered as it is not tenant-aware.")
+            }
+            return isSupported
+        } // All extensions that conform to TenantAware protocol
+        let allExtensions = [Configuration.self] + tenantAwareExtensions
+        let nativeExtensions = allExtensions.filter({$0.self is Extension.Type}) as? [Extension.Type] ?? []
+
+        let eventHub = EventHub.create(tenant: .id(tenantID))
+        nativeExtensions.forEach {
+            eventHub.registerExtension($0) { _ in
+                if registeredCounter.incrementAndGet() == allExtensions.count {
+                    eventHub.start()
+                    completion?()
+                    return
+                }
+            }
+        }
+    }
+
+    static func dispatch(tenantID: String, event: Event) {
+        let eventHub = EventHub.instance(tenant: .id(tenantID))
+        eventHub?.dispatch(event: event)
+    }
+
+    /// Configure the SDK by downloading the remote configuration file hosted on Adobe servers
+    /// specified by the given application ID. The configuration file is cached once downloaded
+    /// and used in subsequent calls to this API. If the remote file is updated after the first
+    /// download, the updated file is downloaded and replaces the cached file.
+    /// - Parameter appId: A unique identifier assigned to the app instance by Adobe Launch
+    static func configureWith(tenantID: String, appId: String) {
+        let event = Event(name: CoreConstants.EventNames.CONFIGURE_WITH_APP_ID, type: EventType.configuration, source: EventSource.requestContent,
+                          data: [CoreConstants.Keys.JSON_APP_ID: appId])
+        MobileCore.dispatch(tenantID: tenantID, event: event)
+    }
+
+    /// Configure the SDK by reading a local file containing the JSON configuration. On application relaunch,
+    /// the configuration from the file at `filePath` is not preserved and this method must be called again if desired.
+    /// - Parameter filePath: Absolute path to a local configuration file.
+    static func configureWith(tenantID: String, filePath: String) {
+        let event = Event(name: CoreConstants.EventNames.CONFIGURE_WITH_FILE_PATH, type: EventType.configuration, source: EventSource.requestContent,
+                          data: [CoreConstants.Keys.JSON_FILE_PATH: filePath])
+        MobileCore.dispatch(tenantID: tenantID, event: event)
+    }
+
+    /// Update the current SDK configuration with specific key/value pairs. Keys not found in the current
+    /// configuration are added. Configuration updates are preserved and applied over existing or new
+    /// configuration even across application restarts.
+    ///
+    /// Using `nil` values is allowed and effectively removes the configuration parameter from the current configuration.
+    /// - Parameter configDict: configuration key/value pairs to be updated or added.
+    static func updateConfigurationWith(tenantID: String, configDict: [String: Any]) {
+        let event = Event(name: CoreConstants.EventNames.CONFIGURATION_UPDATE, type: EventType.configuration, source: EventSource.requestContent,
+                          data: [CoreConstants.Keys.UPDATE_CONFIG: configDict])
+        MobileCore.dispatch(tenantID: tenantID, event: event)
+    }
+
+    /// Clears the changes made by ``updateConfigurationWith(configDict:)`` and ``setPrivacyStatus(_:)`` to the initial configuration
+    /// provided by either ``configureWith(appId:)`` or ``configureWith(filePath:)``
+    static func clearUpdatedConfiguration(tenantID: String) {
+        let event = Event(name: CoreConstants.EventNames.CLEAR_UPDATED_CONFIGURATION, type: EventType.configuration, source: EventSource.requestContent, data: [CoreConstants.Keys.CLEAR_UPDATED_CONFIG: true])
+        MobileCore.dispatch(tenantID: tenantID, event: event)
+    }
+
+    /// Sets the `PrivacyStatus` for this SDK. The set privacy status is preserved and applied over any new
+    /// configuration changes from calls to configureWithAppId or configureWithFileInPath,
+    /// even across application restarts.
+    /// - Parameter status: `PrivacyStatus` to be set for the SDK
+    static func setPrivacyStatus(tenantID: String, _ status: PrivacyStatus) {
+        updateConfigurationWith(tenantID: tenantID, configDict: [CoreConstants.Keys.GLOBAL_CONFIG_PRIVACY: status.rawValue])
+    }
+
+    /// Gets the currently configured `PrivacyStatus` and returns it via `completion`
+    /// - Parameter completion: Invoked with the current `PrivacyStatus`
+    static func getPrivacyStatus(tenantID: String, completion: @escaping (PrivacyStatus) -> Void) {
+        let event = Event(name: CoreConstants.EventNames.PRIVACY_STATUS_REQUEST, type: EventType.configuration, source: EventSource.requestContent, data: [CoreConstants.Keys.RETRIEVE_CONFIG: true])
+
+        let eventHub = EventHub.create(tenant: .id(tenantID))
+        eventHub.registerResponseListener(triggerEvent: event, timeout: CoreConstants.API_TIMEOUT) { responseEvent in
+            guard let privacyStatusString = responseEvent?.data?[CoreConstants.Keys.GLOBAL_CONFIG_PRIVACY] as? String else {
+                return completion(PrivacyStatus.unknown)
+            }
+            completion(PrivacyStatus(rawValue: privacyStatusString) ?? PrivacyStatus.unknown)
+        }
+
+        MobileCore.dispatch(tenantID: tenantID, event: event)
+    }
+}

--- a/AEPCore/Sources/core/MobileCore.swift
+++ b/AEPCore/Sources/core/MobileCore.swift
@@ -16,7 +16,8 @@ import Foundation
 /// Core extension for the Adobe Experience Platform SDK
 @objc(AEPMobileCore)
 public final class MobileCore: NSObject {
-    private static let LOG_TAG = "MobileCore"
+    internal static let LOG_TAG = "MobileCore"
+
     /// Current version of the Core extension
     @objc public static var extensionVersion: String {
         let wrapperType = EventHub.shared.getWrapperType()

--- a/AEPCore/Sources/eventhub/EventHub+Tenant.swift
+++ b/AEPCore/Sources/eventhub/EventHub+Tenant.swift
@@ -1,0 +1,55 @@
+//
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+// Todo: The tenantIDs should be persisted internally by the SDK for cleanup and migration purposes. 
+final class EventHubManager {
+    // Store for tenant-specific EventHub instances
+    private static var tenantStore: [Tenant: EventHub] = [
+        .default: EventHub(tenant: .default)
+    ]
+
+    // Dispatch queue for thread safety
+    private static let accessQueue = DispatchQueue(label: "com.eventHubManager.queue")
+
+    // Create or retrieve an EventHub instance for a specific tenant
+    static func createInstance(tenant: Tenant) -> EventHub {
+        return accessQueue.sync {
+            if let hub = tenantStore[tenant] {
+                return hub
+            } else {
+                let newHub = EventHub(tenant: tenant)
+                tenantStore[tenant] = newHub
+                return newHub
+            }
+        }
+    }
+
+    // Retrieve an EventHub instance for a specific tenant or return the default instance
+    static func instance(tenant: Tenant = .default) -> EventHub? {
+        return accessQueue.sync {
+            tenantStore[tenant]
+        }
+    }
+}
+
+extension EventHub {
+    static func instance(tenant: Tenant = .default) -> EventHub? {
+        return EventHubManager.instance(tenant: tenant)
+    }
+
+    static func create(tenant: Tenant) -> EventHub {
+        return EventHubManager.createInstance(tenant: tenant)
+    }
+}

--- a/AEPCore/Sources/eventhub/EventHub.swift
+++ b/AEPCore/Sources/eventhub/EventHub.swift
@@ -21,7 +21,8 @@ public typealias EventPreprocessor = (Event) -> Event
 
 /// Responsible for delivering events to listeners and maintaining registered extension's lifecycle.
 final class EventHub {
-    private let LOG_TAG = "EventHub"
+    private let LOG_TAG: String
+    private let tenant: Tenant
     private let eventHubQueue = DispatchQueue(label: "com.adobe.eventHub.queue")
     private var registeredExtensions = ThreadSafeDictionary<String, ExtensionContainer>(identifier: "com.adobe.eventHub.registeredExtensions.queue")
     private let eventNumberMap = ThreadSafeDictionary<UUID, Int>(identifier: "com.adobe.eventHub.eventNumber.queue")
@@ -30,18 +31,26 @@ final class EventHub {
     private let eventQueue = OperationOrderer<Event>("EventHub")
     private var preprocessors = ThreadSafeArray<EventPreprocessor>(identifier: "com.adobe.eventHub.preprocessors.queue")
     private var started = false // true if the `EventHub` is started, false otherwise. Should only be accessed from within the `eventHubQueue`
-    private var eventHistory = EventHistory()
+    private var eventHistory: EventHistory?
     private var wrapperType: WrapperType = .none
+
+    // Keeping it for now to limit build failures.
     #if DEBUG
-        public internal(set) static var shared = EventHub()
+        public internal(set) static var shared = EventHub.create(tenant: .default)
     #else
-        internal static let shared = EventHub()
+        internal static let shared = EventHub.create(tenant: .default)
     #endif
 
     // MARK: - Internal API
 
     /// Creates a new instance of `EventHub`
-    init() {
+    init(tenant: Tenant) {
+        LOG_TAG = "EventHub".tenantAwareName(for: tenant)
+        self.tenant = tenant        
+
+        Log.debug(label: LOG_TAG, "Initializing EventHub for tenant \(tenant.description)")
+
+        eventHistory = EventHistory(tenant: tenant)
         // setup a place-holder extension container for `EventHub` so we can shared and retrieve state
         registerExtension(EventHubPlaceholderExtension.self, completion: { _ in })
 
@@ -136,7 +145,7 @@ final class EventHub {
             // Init the extension on a dedicated queue
             let extensionTypeName = "com.adobe.eventhub.extension.\(type.typeName)"
             let extensionQueue = DispatchQueue(label: extensionTypeName)
-            let extensionContainer = ExtensionContainer(extensionTypeName, type, extensionQueue, completion: completion)
+            let extensionContainer = ExtensionContainer(self, tenant, extensionTypeName, type, extensionQueue, completion: completion)
             self.registeredExtensions[type.typeName] = extensionContainer
             Log.debug(label: self.LOG_TAG, "\(type.typeName) successfully registered.")
         }

--- a/AEPCore/Sources/eventhub/Extension.swift
+++ b/AEPCore/Sources/eventhub/Extension.swift
@@ -191,7 +191,8 @@ public extension Extension {
 
     /// Register a event preprocessor
     /// - Parameter preprocessor: The `EventPreprocessor`
-    internal func registerPreprocessor(_ preprocessor: @escaping EventPreprocessor) {
-        EventHub.shared.registerPreprocessor(preprocessor)
+    ///  This is an internal API and not a breaking change.
+    internal func registerPreprocessor( _ tenant: Tenant, _ preprocessor: @escaping EventPreprocessor) {
+        EventHub.instance(tenant: tenant)?.registerPreprocessor(preprocessor)
     }
 }

--- a/AEPCore/Sources/eventhub/ExtensionContainer.swift
+++ b/AEPCore/Sources/eventhub/ExtensionContainer.swift
@@ -19,6 +19,8 @@ import Foundation
 class ExtensionContainer {
     private static let LOG_TAG = "ExtensionContainer"
 
+    private weak var eventHub: EventHub?
+
     /// The extension held in this container
     private var _exten: Extension?
     var exten: Extension? {
@@ -58,7 +60,8 @@ class ExtensionContainer {
         set { containerQueue.async { self._lastProcessedEvent = newValue } }
     }
 
-    init(_ name: String, _ type: Extension.Type, _ queue: DispatchQueue, completion: @escaping (EventHubError?) -> Void) {
+    init(_ eventHub: EventHub, _ tenant: Tenant, _ name: String, _ type: Extension.Type, _ queue: DispatchQueue, completion: @escaping (EventHubError?) -> Void) {
+        self.eventHub = eventHub
         extensionQueue = queue
         containerQueue = DispatchQueue(label: "\(name).containerQueue")
         eventOrderer = OperationOrderer<Event>("\(name).operationOrderer")
@@ -67,7 +70,11 @@ class ExtensionContainer {
 
         // initialize the backing extension on the extension queue
         extensionQueue.async {
-            self.exten = type.init(runtime: self)
+            if let type = type as? TenantAwareExtension.Type {
+                self.exten = type.init(runtime: self, tenant: tenant)
+            } else {
+                self.exten = type.init(runtime: self)
+            }
             guard let unwrappedExtension = self.exten else {
                 Log.error(label: "\(ExtensionContainer.LOG_TAG):\(#function)", "Failed to initialize extension of type: \(type)")
                 completion(.extensionInitializationFailure)
@@ -100,8 +107,8 @@ class ExtensionContainer {
 
 extension ExtensionContainer: ExtensionRuntime {
     func unregisterExtension() {
-        guard let exten = exten else { return }
-        EventHub.shared.unregisterExtension(type(of: exten), completion: {_ in })
+        guard let exten = exten, let eventHub = eventHub else { return }
+        eventHub.unregisterExtension(type(of: exten), completion: {_ in })
     }
 
     public func registerListener(type: String, source: String, listener: @escaping EventListener) {
@@ -110,47 +117,58 @@ extension ExtensionContainer: ExtensionRuntime {
     }
 
     func registerResponseListener(triggerEvent: Event, timeout: TimeInterval, listener: @escaping EventResponseListener) {
-        EventHub.shared.registerResponseListener(triggerEvent: triggerEvent, timeout: timeout, listener: listener)
+        guard let eventHub = eventHub else { return }
+        eventHub.registerResponseListener(triggerEvent: triggerEvent, timeout: timeout, listener: listener)
     }
 
     func dispatch(event: Event) {
-        EventHub.shared.dispatch(event: event)
+        guard let eventHub = eventHub else { return }
+        eventHub.dispatch(event: event)
     }
 
     func createSharedState(data: [String: Any], event: Event?) {
-        EventHub.shared.createSharedState(extensionName: sharedStateName, data: data, event: event)
+        guard let eventHub = eventHub else { return }
+        eventHub.createSharedState(extensionName: sharedStateName, data: data, event: event)
     }
 
     func createPendingSharedState(event: Event?) -> SharedStateResolver {
-        return EventHub.shared.createPendingSharedState(extensionName: sharedStateName, event: event)
+        guard let eventHub = eventHub else { return { _ in } }
+        return eventHub.createPendingSharedState(extensionName: sharedStateName, event: event)
     }
 
     func getSharedState(extensionName: String, event: Event?, barrier: Bool = true) -> SharedStateResult? {
-        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier)
+        guard let eventHub = eventHub else { return nil }
+        return eventHub.getSharedState(extensionName: extensionName, event: event, barrier: barrier)
     }
 
     func getSharedState(extensionName: String, event: Event?, barrier: Bool = true, resolution: SharedStateResolution = .any) -> SharedStateResult? {
-        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier, resolution: resolution)
+        guard let eventHub = eventHub else { return nil }
+        return eventHub.getSharedState(extensionName: extensionName, event: event, barrier: barrier, resolution: resolution)
     }
 
     func createXDMSharedState(data: [String: Any], event: Event?) {
-        EventHub.shared.createSharedState(extensionName: sharedStateName, data: data, event: event, sharedStateType: .xdm)
+        guard let eventHub = eventHub else { return }
+        return eventHub.createSharedState(extensionName: sharedStateName, data: data, event: event, sharedStateType: .xdm)
     }
 
     func createPendingXDMSharedState(event: Event?) -> SharedStateResolver {
-        return EventHub.shared.createPendingSharedState(extensionName: sharedStateName, event: event, sharedStateType: .xdm)
+        guard let eventHub = eventHub else { return { _ in } }
+        return eventHub.createPendingSharedState(extensionName: sharedStateName, event: event, sharedStateType: .xdm)
     }
 
     func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool = false) -> SharedStateResult? {
-        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier, sharedStateType: .xdm)
+        guard let eventHub = eventHub else { return nil }
+        return eventHub.getSharedState(extensionName: extensionName, event: event, barrier: barrier, sharedStateType: .xdm)
     }
 
     func getXDMSharedState(extensionName: String, event: Event?, barrier: Bool = true, resolution: SharedStateResolution = .any) -> SharedStateResult? {
-        return EventHub.shared.getSharedState(extensionName: extensionName, event: event, barrier: barrier, resolution: resolution, sharedStateType: .xdm)
+        guard let eventHub = eventHub else { return nil }
+        return eventHub.getSharedState(extensionName: extensionName, event: event, barrier: barrier, resolution: resolution, sharedStateType: .xdm)
     }
 
     func getHistoricalEvents(_ requests: [EventHistoryRequest], enforceOrder: Bool, handler: @escaping ([EventHistoryResult]) -> Void) {
-        EventHub.shared.getHistoricalEvents(requests, enforceOrder: enforceOrder, handler: handler)
+        guard let eventHub = eventHub else { return }
+        eventHub.getHistoricalEvents(requests, enforceOrder: enforceOrder, handler: handler)
     }
 
     func startEvents() {
@@ -162,7 +180,7 @@ extension ExtensionContainer: ExtensionRuntime {
     }
 
     func shutdown() {
-        eventOrderer.waitToStop()
+        eventOrderer.waitToStop()      
     }
 }
 

--- a/AEPCore/Sources/eventhub/Tenant.swift
+++ b/AEPCore/Sources/eventhub/Tenant.swift
@@ -1,0 +1,41 @@
+//
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+public enum Tenant: Hashable {
+    case `default`
+    case id(String)
+
+    var id: String? {
+        switch self {
+        case .default:
+            return nil
+        case .id(let id):
+            return id
+        }
+    }
+
+    var description: String {
+        id ?? "default"        
+    }
+}
+
+public extension String {
+    func tenantAwareName(for tenant: Tenant) -> String {
+        guard let tenantID = tenant.id else {
+            return self
+        }
+        return "\(self)-\(tenantID)"
+    }
+}

--- a/AEPCore/Sources/eventhub/TenantAwareExtension.swift
+++ b/AEPCore/Sources/eventhub/TenantAwareExtension.swift
@@ -17,7 +17,7 @@ public protocol TenantAwareExtension: Extension {
     /// Initializes the extension with the provided runtime and tenant.
     ///
     /// - Parameters:
-    ///   - runtime: The runtime environment in which the extension will operate.
+    ///   - runtime: The `ExtensionRuntime` instance to communicate with `EventHub`.
     ///   - tenant: The tenant configuration for the extension.
     /// - Returns: An instance of the extension, or nil if initialization fails.
     init?(runtime: ExtensionRuntime, tenant: Tenant)    

--- a/AEPCore/Sources/eventhub/TenantAwareExtension.swift
+++ b/AEPCore/Sources/eventhub/TenantAwareExtension.swift
@@ -1,0 +1,24 @@
+//
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+public protocol TenantAwareExtension: Extension {
+    /// Initializes the extension with the provided runtime and tenant.
+    ///
+    /// - Parameters:
+    ///   - runtime: The runtime environment in which the extension will operate.
+    ///   - tenant: The tenant configuration for the extension.
+    /// - Returns: An instance of the extension, or nil if initialization fails.
+    init?(runtime: ExtensionRuntime, tenant: Tenant)    
+}

--- a/AEPCore/Sources/eventhub/history/EventHistory.swift
+++ b/AEPCore/Sources/eventhub/history/EventHistory.swift
@@ -20,8 +20,9 @@ class EventHistory {
     /// Default initializer.
     ///
     /// - Returns `nil` if the database cannot be initialized.
-    init?() {
-        guard let db = EventHistoryDatabase(dispatchQueue: DispatchQueue.init(label: "EventHistory")) else {
+    init?(tenant: Tenant) {
+        let dispatchQueue = DispatchQueue.init(label: "EventHistory".tenantAwareName(for: tenant))
+        guard let db = EventHistoryDatabase(tenant: tenant, dispatchQueue: dispatchQueue) else {
             return nil
         }
 

--- a/AEPCore/Sources/eventhub/history/EventHistoryDatabase.swift
+++ b/AEPCore/Sources/eventhub/history/EventHistoryDatabase.swift
@@ -16,9 +16,9 @@ import AEPServices
 class EventHistoryDatabase {
     let LOG_PREFIX = "Event History Database"
 
+    let tenant: Tenant
     let dispatchQueue: DispatchQueue
-
-    let dbName = "com.adobe.eventHistory"
+    let dbName: String
     let dbFilePath: FileManager.SearchPathDirectory = .cachesDirectory
 
     let tableName = "Events"
@@ -30,8 +30,11 @@ class EventHistoryDatabase {
     /// Default initializer.
     ///
     /// - Returns `nil` if the `DispatchQueue` cannot be initialized.
-    init?(dispatchQueue: DispatchQueue) {
+    init?(tenant: Tenant, dispatchQueue: DispatchQueue) {
+        self.tenant = tenant
         self.dispatchQueue = dispatchQueue
+        self.dbName = "com.adobe.eventHistory".tenantAwareName(for: tenant)
+
         guard createTable() else {
             Log.warning(label: LOG_PREFIX, "Failed to initialize Event History Database.")
             return nil

--- a/AEPSignal/Sources/Signal.swift
+++ b/AEPSignal/Sources/Signal.swift
@@ -17,35 +17,43 @@ import Foundation
 @objc(AEPMobileSignal)
 @available(iOSApplicationExtension, unavailable)
 @available(tvOSApplicationExtension, unavailable)
-public class Signal: NSObject, Extension {
+public class Signal: NSObject, TenantAwareExtension {
 
     private(set) var hitQueue: HitQueuing
 
     // MARK: - Extension
 
     public let runtime: ExtensionRuntime
+    public let tenant: Tenant
 
     public let name = SignalConstants.EXTENSION_NAME
     public let friendlyName = SignalConstants.FRIENDLY_NAME
     public static let extensionVersion = SignalConstants.EXTENSION_VERSION
     public let metadata: [String: String]? = nil
 
-    public required init?(runtime: ExtensionRuntime) {
-        guard let dataQueue = ServiceProvider.shared.dataQueueService.getDataQueue(label: name) else {
+    public required init?(runtime: ExtensionRuntime, tenant: Tenant) {
+        self.runtime = runtime
+        self.tenant = tenant
+
+        let dataQueueName = name.tenantAwareName(for: tenant)
+        guard let dataQueue = ServiceProvider.shared.dataQueueService.getDataQueue(label: dataQueueName) else {
             Log.error(label: SignalConstants.LOG_PREFIX, "Signal extension could not be initialized - unable to create a DataQueue.")
             return nil
         }
-
         hitQueue = PersistentHitQueue(dataQueue: dataQueue, processor: SignalHitProcessor())
-        self.runtime = runtime
 
         super.init()
+    }
+
+    public required convenience init?(runtime: ExtensionRuntime) {
+        self.init(runtime: runtime, tenant: .default)
     }
 
     // internal init added for testing
     internal init(runtime: ExtensionRuntime, hitQueue: HitQueuing) {
         self.hitQueue = hitQueue
         self.runtime = runtime
+        self.tenant = .default
         super.init()
     }
 

--- a/TestApps/TestApp_Swift/AppDelegate.swift
+++ b/TestApps/TestApp_Swift/AppDelegate.swift
@@ -20,7 +20,7 @@ import BackgroundTasks
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    private let LAUNCH_ENVIRONMENT_FILE_ID = ""
+    private let LAUNCH_ENVIRONMENT_FILE_ID = "94f571f308d5/bc09a100649b/launch-6df8e3eea690-development"
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -30,12 +30,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                           Lifecycle.self,
                           Signal.self]
 
+        // Default tenant
         MobileCore.registerExtensions(extensions, {
             MobileCore.configureWith(appId: self.LAUNCH_ENVIRONMENT_FILE_ID)
 
             if appState != .background {
                 MobileCore.lifecycleStart(additionalContextData: nil)
             }
+        })
+
+
+        // Initializing a new tenant. Only extensions which are tenant aware will be initialized for this instance.
+        let partnerTenant = "partner"
+        let partnerLaunchEnvironmentID = "94f571f308d5/39273f51e930/launch-00ac4ce72151-development"
+
+        MobileCore.registerExtensions(tenantID: partnerTenant, extensions, {
+            MobileCore.configureWith(tenantID: partnerTenant, appId: partnerLaunchEnvironmentID)
         })
 
         // If testing background, edit test app scheme -> options -> background fetch -> Check "launch app due to background fetch event"


### PR DESCRIPTION
This PR includes a Proof of Concept for supporting multiple SDK instances by creating separate Event Hub instances for each tenant. 

### TenantAwareExtension class

Currently, each extension is instantiated only once throughout the app lifecycle. To enable extensions to function in a multi-tenant environment, one option is to support multiple instances of extensions, each associated with a specific tenant. 
The Extension should:
- Ensure data separation by initializing service instances (e.g., named collections, caches, and data queues) for each tenant.
- Update the extension’s public API to accommodate the multi-tenant changes in Core.

Added the new `TenantAwareExtension` class, which exposes the tenant as part of the initializer to enable the extension to manage its data per tenant. This class supports incremental adoption by ensuring that Core will only register extensions that implement this protocol when operating in multi-tenant environments. 

Minimal modifications were only necessary to update the Configuration and Signal extensions for tenant awareness.

```
public protocol TenantAwareExtension: Extension {
    /// Initializes the extension with the provided runtime and tenant.
    ///
    /// - Parameters:
	///   - runtime: The `ExtensionRuntime` instance to communicate with `EventHub`.
    ///   - tenant: The tenant configuration for the extension.
    /// - Returns: An instance of the extension, or nil if initialization fails.
    init?(runtime: ExtensionRuntime, tenant: Tenant)    
}
```

Alternatives Considered

1.	Add an API to `ExtensionRuntime` for the extension to query the tenant it is supposed to work on.
- Still need a way to signal whether an Extension is tenant aware.
- Better to pass the tenant as part of the extension contract rather than letting the extension query from runtime.	
- Complex to design if a single extension needs to handle multiple tenants.

2. Use extension.metadata or new extension methods to indicate support for a multi-tenant environment.
- Core would need to create an instance to determine if the extension supports multiple tenants.
		
3. Add an API to TenantAwareExtension instead of creating a new initializer.

```
public protocol TenantAwareExtension: Extension {
	/// Initializes the extension to run for a particular tenant
	func initializeForTenant(tenant: Tenant) -> Bool
}
```
	
- Simplifies extending support for a single extension handling multiple tenants.
- Option 1 doesn’t support this as it would require updates to the ExtensionContainer lifecycle. I will look into it as part of Option 2 but prefer creating a new subclass for these cases as they’re rare and not needed soon.
- Additional changes would be required to initialize services and other extension members outside of the initializer. 

### Tenant Class and helpers
- Defined a new Tenant class and added extension functions to simplify tenant management, such as retrieving tenant aware names. 


Further work, to be addressed in subsequent tickets, will include:
- Persist tenant IDs and handle migration across tenants. 
- Better way to include tenant information in Log messages.
- Public APIs for multi tenant scenarios (The public APIs introduced in this PR are solely for testing purposes)